### PR TITLE
Added flycast reset command to support X-, X-0, X-1, X-2, and X-3

### DIFF
--- a/src/hostLib/ScreenData.hpp
+++ b/src/hostLib/ScreenData.hpp
@@ -41,6 +41,9 @@ class ScreenData
         //! @param[in] numWords  Number of words to write
         void setData(uint32_t* data, uint32_t startIndex=0, uint32_t numWords=NUM_SCREEN_WORDS);
 
+        //! Resets the screen to its initialized default
+        void resetToDefault();
+
         //! @returns true if new data is available since last call to readData
         bool isNewDataAvailable() const;
 
@@ -53,6 +56,8 @@ class ScreenData
         static const uint32_t NUM_SCREEN_WORDS = 48;
 
     private:
+        //! The default screen data on initialization and resetToDefault()
+        static const uint32_t DEFAULT_SCREEN_DATA[NUM_SCREEN_WORDS];
         //! Mutex used to ensure integrity of data between multiple cores
         MutexInterface& mMutex;
         //! The current screen data

--- a/src/hostLib/parsers/FlycastCommandParser.cpp
+++ b/src/hostLib/parsers/FlycastCommandParser.cpp
@@ -184,6 +184,7 @@ void FlycastCommandParser::submit(const char* chars, uint32_t len)
             {
                 // Single player special case - always send to the one available, regardless of address
                 idx = 0;
+                packet.frame.senderAddr = *senderAddress;
             }
             else
             {

--- a/src/hostLib/parsers/FlycastCommandParser.cpp
+++ b/src/hostLib/parsers/FlycastCommandParser.cpp
@@ -83,46 +83,51 @@ void FlycastCommandParser::submit(const char* chars, uint32_t len)
         --eol;
     }
 
-    // Special case
-    // Either X- to reset all or one of {X0-, X1-, X2-, X3-} to reset a specific player
-    if (iter < eol && *(eol - 1) == '-')
+    // Check for special commanding
+    if (iter < eol)
     {
-        // Reset command
-
-        // Remove minus
-        eol--;
-        int idx = -1;
-        if (iter < eol)
+        switch(*iter)
         {
-            std::string number;
-            number.assign(iter, eol - iter);
-            try
+            // Either X- to reset all or one of {X-0, X-1, X-2, X-3} to reset a specific player
+            case '-':
             {
-                idx = std::stoi(number);
-            }
-            catch(...)
-            {
-                // Default to all
-                idx = -1;
-            }
-        }
+                // Remove minus
+                ++iter;
+                int idx = -1;
+                if (iter < eol)
+                {
+                    std::string number;
+                    number.assign(iter, eol - iter);
+                    try
+                    {
+                        idx = std::stoi(number);
+                    }
+                    catch(...)
+                    {
+                        // Default to all
+                        idx = -1;
+                    }
+                }
 
-        // Reset screen data
-        if (idx < 0)
-        {
-            // all
-            for (std::shared_ptr<PlayerData>& playerData : mPlayerData)
-            {
-                playerData->screenData.resetToDefault();
+                // Reset screen data
+                if (idx < 0)
+                {
+                    // all
+                    for (std::shared_ptr<PlayerData>& playerData : mPlayerData)
+                    {
+                        playerData->screenData.resetToDefault();
+                    }
+                }
+                else if (static_cast<std::size_t>(idx) < mPlayerData.size())
+                {
+                    mPlayerData[idx]->screenData.resetToDefault();
+                }
             }
-        }
-        else if (static_cast<std::size_t>(idx) < mPlayerData.size())
-        {
-            mPlayerData[idx]->screenData.resetToDefault();
-        }
+            return;
 
-        // Nothing else to do
-        return;
+            // No special case
+            default: break;
+        }
     }
 
     while (iter < eol)

--- a/src/hostLib/parsers/FlycastCommandParser.cpp
+++ b/src/hostLib/parsers/FlycastCommandParser.cpp
@@ -180,11 +180,19 @@ void FlycastCommandParser::submit(const char* chars, uint32_t len)
             int32_t idx = -1;
             const uint8_t* senderAddress = mSenderAddresses;
 
-            for (uint32_t i = 0; i < mNumSenders && idx < 0; ++i, ++senderAddress)
+            if (mNumSenders == 1)
             {
-                if (sender == *senderAddress)
+                // Single player special case - always send to the one available, regardless of address
+                idx = 0;
+            }
+            else
+            {
+                for (uint32_t i = 0; i < mNumSenders && idx < 0; ++i, ++senderAddress)
                 {
-                    idx = i;
+                    if (sender == *senderAddress)
+                    {
+                        idx = i;
+                    }
                 }
             }
 

--- a/src/hostLib/parsers/FlycastCommandParser.cpp
+++ b/src/hostLib/parsers/FlycastCommandParser.cpp
@@ -185,6 +185,7 @@ void FlycastCommandParser::submit(const char* chars, uint32_t len)
                 // Single player special case - always send to the one available, regardless of address
                 idx = 0;
                 packet.frame.senderAddr = *senderAddress;
+                packet.frame.recipientAddr = (packet.frame.recipientAddr & 0x3F) | *senderAddress;
             }
             else
             {

--- a/src/hostLib/parsers/FlycastCommandParser.hpp
+++ b/src/hostLib/parsers/FlycastCommandParser.hpp
@@ -4,6 +4,8 @@
 
 #include "PrioritizedTxScheduler.hpp"
 
+#include "PlayerData.hpp"
+
 #include <memory>
 
 // Command structure: [whitespace]<command-char>[command]<\n>
@@ -15,7 +17,8 @@ public:
     FlycastCommandParser(
         std::shared_ptr<PrioritizedTxScheduler>* schedulers,
         const uint8_t* senderAddresses,
-        uint32_t numSenders);
+        uint32_t numSenders,
+        const std::vector<std::shared_ptr<PlayerData>>& playerData);
 
     //! @returns the string of command characters this parser handles
     virtual const char* getCommandChars() final;
@@ -30,4 +33,5 @@ private:
     std::shared_ptr<PrioritizedTxScheduler>* const mSchedulers;
     const uint8_t* const mSenderAddresses;
     const uint32_t mNumSenders;
+    std::vector<std::shared_ptr<PlayerData>> mPlayerData;
 };

--- a/src/main/Host/host.cpp
+++ b/src/main/Host/host.cpp
@@ -70,7 +70,8 @@ void core1()
     };
     CriticalSectionMutex screenMutexes[numDevices];
     std::shared_ptr<ScreenData> screenData[numDevices];
-    std::shared_ptr<PlayerData> playerData[numDevices];
+    std::vector<std::shared_ptr<PlayerData>> playerData;
+    playerData.resize(numDevices);
     DreamcastControllerObserver** observers = get_usb_controller_observers();
     std::shared_ptr<MapleBusInterface> buses[numDevices];
     std::shared_ptr<DreamcastMainNode> dreamcastMainNodes[numDevices];
@@ -100,7 +101,7 @@ void core1()
             &schedulers[0], MAPLE_HOST_ADDRESSES, numDevices));
     ttyParser->addCommandParser(
         std::make_shared<FlycastCommandParser>(
-            &schedulers[0], MAPLE_HOST_ADDRESSES, numDevices));
+            &schedulers[0], MAPLE_HOST_ADDRESSES, numDevices, playerData));
 
     while(true)
     {


### PR DESCRIPTION
- When there is only 1 player available, always send the command to the single player's address, 
- New commands for use with flycast:
`X-` to reset all screens
`X-0`, `X-1`, `X-2`, `X-3` to reset a specific player's screen

Manually tested in a serial console:
```
X-
```
Nothing happens, no error is printed
```
X 0C 01 00 32 00 00 00 04 00 00 00 00 68 00 3F C0 02 01 FC 01 C0 3C 0C 03 FE 06 00 07 98 07 6F 08 00 71 F0 0E FF 10 00 0C 60 1F FF 60 00 02 30 3F 6D C0 00 01 18 36 FF 83 01 F0 14 7F FF BD 06 0E 10 7F 6D CE 38 07 A0 F6 FF 8B C8 07 C0 FF C3 0F 0C 05 40 7F 1F 1F 0E 05 60 7E 67 FD 0B 87 3F C7 8F EB 0D FF F8 F1 33 55 0A BF FF 3D 46 AB 0D 55 63 E1 0F 55 0A AA A0 7B 3A AA 05 55 60 21 E3 56 06 AA A0 3C 82 AA 05 55 60 27 07 56 02 AA A0 21 06 AA 03 55 40 20 07 54 01 AA C0 20 0D AC 00 D5 40 60 1C F8 00 6A 80 70 14 10 00 3F 00 50 22 00 00 18 00 48 22 00 00 0E 00 88 41 00 00 00 00 84 41 00 00 00 01 04 80 80 00 00 01 02
 07 00 01 00
```
I see Rouge! 😄 
```
X-
```
Rouge is gone 😢
``` 
X 0C 01 00 32 00 00 00 04 00 00 00 00 68 00 3F C0 02 01 FC 01 C0 3C 0C 03 FE 06 00 07 98 07 6F 08 00 71 F0 0E FF 10 00 0C 60 1F FF 60 00 02 30 3F 6D C0 00 01 18 36 FF 83 01 F0 14 7F FF BD 06 0E 10 7F 6D CE 38 07 A0 F6 FF 8B C8 07 C0 FF C3 0F 0C 05 40 7F 1F 1F 0E 05 60 7E 67 FD 0B 87 3F C7 8F EB 0D FF F8 F1 33 55 0A BF FF 3D 46 AB 0D 55 63 E1 0F 55 0A AA A0 7B 3A AA 05 55 60 21 E3 56 06 AA A0 3C 82 AA 05 55 60 27 07 56 02 AA A0 21 06 AA 03 55 40 20 07 54 01 AA C0 20 0D AC 00 D5 40 60 1C F8 00 6A 80 70 14 10 00 3F 00 50 22 00 00 18 00 48 22 00 00 0E 00 88 41 00 00 00 00 84 41 00 00 00 01 04 80 80 00 00 01 02
 07 00 01 00
```
Rouge is back! 😄 
```
X-1
```
Nothing happens
```
X-0
```
Rouge is gone 😢