### PR TITLE
148 make images for rp2350 raspberry pi pico 2 and w variants

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,25 +18,15 @@ jobs:
       - name: Build main package for pico
         run: ./build.sh pico
       - name: Build main package for pico2
-        run: ./build.sh pico2
-      - name: Build main package for pico_w
-        run: ./build.sh pico_w
-      - name: Build main package for pico2_w
-        run: ./build.sh pico2_w
+        run: ./build.sh pico2 pico2
       - name: upload binaries to release
         uses: softprops/action-gh-release@v1
         if: ${{startsWith(github.ref, 'refs/tags/') }}
         with:
             files: |
-              dist/client-with-usb-host-pico.uf2
-              dist/host-1p-pico.uf2
-              dist/host-4p-pico.uf2
+              dist/client-with-usb-host.uf2
+              dist/host-1p.uf2
+              dist/host-4p.uf2
               dist/client-with-usb-host-pico2.uf2
               dist/host-1p-pico2.uf2
               dist/host-4p-pico2.uf2
-              dist/client-with-usb-host-pico_w.uf2
-              dist/host-1p-pico_w.uf2
-              dist/host-4p-pico_w.uf2
-              dist/client-with-usb-host-pico2_w.uf2
-              dist/host-1p-pico2_w.uf2
-              dist/host-4p-pico2_w.uf2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,28 @@ jobs:
         run: sudo apt -y install gcc-arm-none-eabi build-essential
       - name: Install dependencies
         run: git submodule update --recursive --init
-      - name: Build main package
-        run: ./build.sh
+      - name: Build main package for pico
+        run: ./build.sh pico
+      - name: Build main package for pico2
+        run: ./build.sh pico2
+      - name: Build main package for pico_w
+        run: ./build.sh pico_w
+      - name: Build main package for pico2_w
+        run: ./build.sh pico2_w
       - name: upload binaries to release
         uses: softprops/action-gh-release@v1
         if: ${{startsWith(github.ref, 'refs/tags/') }}
         with:
             files: |
-              dist/client-with-usb-host.uf2
-              dist/host-1p.uf2
-              dist/host-4p.uf2
+              dist/client-with-usb-host-pico.uf2
+              dist/host-1p-pico.uf2
+              dist/host-4p-pico.uf2
+              dist/client-with-usb-host-pico2.uf2
+              dist/host-1p-pico2.uf2
+              dist/host-4p-pico2.uf2
+              dist/client-with-usb-host-pico_w.uf2
+              dist/host-1p-pico_w.uf2
+              dist/host-4p-pico_w.uf2
+              dist/client-with-usb-host-pico2_w.uf2
+              dist/host-1p-pico2_w.uf2
+              dist/host-4p-pico2_w.uf2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,13 @@ jobs:
         run: sudo apt -y install gcc-arm-none-eabi build-essential
       - name: Install dependencies
         run: git submodule update --recursive --init
-      - name: Build main package
-        run: ./build.sh
+      - name: Build main package for pico
+        run: ./build.sh pico
+      - name: Build main package for pico2
+        run: ./build.sh pico2
+      - name: Build main package for pico_w
+        run: ./build.sh pico_w
+      - name: Build main package for pico2_w
+        run: ./build.sh pico2_w
       - name: Build and run unit tests
         run: ./run_tests.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,10 +24,6 @@ jobs:
       - name: Build main package for pico
         run: ./build.sh pico
       - name: Build main package for pico2
-        run: ./build.sh pico2
-      - name: Build main package for pico_w
-        run: ./build.sh pico_w
-      - name: Build main package for pico2_w
-        run: ./build.sh pico2_w
+        run: ./build.sh pico2 pico2
       - name: Build and run unit tests
         run: ./run_tests.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 CMakeCache.txt
 CMakeFiles/*
 build/*
+build-*/*
 build-test/*
 dist/*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -62,7 +62,11 @@
         "iomanip": "cpp",
         "variant": "cpp",
         "printf.h": "c",
-        "bitset": "cpp"
+        "bitset": "cpp",
+        "*.ipp": "cpp",
+        "ranges": "cpp",
+        "regex": "cpp",
+        "valarray": "cpp"
     },
     "cmake.configureOnOpen": false
 }

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ For reference, the following is the pinout for the Dreamcast controller port. Ta
 
 ## Selecting the Appropriate Binary
 
-Each [release](https://github.com/OrangeFox86/DreamcastControllerUsbPico/releases) will contain multiple uf2 files. Currently, there are 3 flavors of these binaries.
+Each [release](https://github.com/OrangeFox86/DreamcastControllerUsbPico/releases) will contain multiple uf2 files. Currently, there are 3 flavors of these binaries for each of the Pico Version 1 and Pico Version 2 boards.
 
 - **host-1p.uf2**: [Host mode](#connecting-the-hardware-for-host-mode) configuration, only `1P` active - all operating systems support this
 - **host-4p.uf2**: [Host mode](#connecting-the-hardware-for-host-mode) configuration, `1P`, `2P`, `3P`, and `4P` active - this is more problematic when used on Windows as controllers won't properly enumerate

--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ For reference, the following is the pinout for the Dreamcast controller port. Ta
 
 ## Selecting the Appropriate Binary
 
-Each [release](https://github.com/OrangeFox86/DreamcastControllerUsbPico/releases) will contain multiple uf2 files. Currently, there are 3 flavors of these binaries for each of the Pico Version 1 and Pico Version 2 boards.
+Each [release](https://github.com/OrangeFox86/DreamcastControllerUsbPico/releases) will contain multiple uf2 files. Currently, there are 3 flavors of these binaries for each of the Pico Version 1 (RP2040) and Pico Version 2 (RP2350) boards. The W variants of the hardware may also be used, but the status LED will not be functional.
 
-- **host-1p.uf2**: [Host mode](#connecting-the-hardware-for-host-mode) configuration, only `1P` active - all operating systems support this
-- **host-4p.uf2**: [Host mode](#connecting-the-hardware-for-host-mode) configuration, `1P`, `2P`, `3P`, and `4P` active - this is more problematic when used on Windows as controllers won't properly enumerate
-- **client-with-usb-host.uf2**: [Client mode](#connecting-the-hardware-for-client-mode) configuration supporting a single Dualshock4 controller connected to the USB port
+- **host-1p*.uf2**: [Host mode](#connecting-the-hardware-for-host-mode) configuration, only `1P` active - all operating systems support this
+- **host-4p*.uf2**: [Host mode](#connecting-the-hardware-for-host-mode) configuration, `1P`, `2P`, `3P`, and `4P` active - this is more problematic when used on Windows as controllers won't properly enumerate
+- **client-with-usb-host*.uf2**: [Client mode](#connecting-the-hardware-for-client-mode) configuration supporting a single Dualshock4 controller connected to the USB port
 
 ## Loading the UF2 Binary
 
@@ -87,7 +87,7 @@ Hold the BOOTSEL button on the Pico while plugging the USB connection into your 
 
 ### Host Mode Tips
 
-- The LED on the Pico board may be used for quick status - when connected to USB, it should remain on when no button is pressed on any controller and turn off once a button is pressed.
+- The LED on the W variants of the Pico board will not work with this project. On the standard Pico and Pico2 boards, the LED may be used for quick status - when connected to USB, it should remain on when no button is pressed on any controller and turn off once a button is pressed.
 - The included file `formatted_storage.bin` may be used to delete and format a VMU attached to a controller when this project is used in host mode. For example, rename this file vmu0.bin and copy to DC-Memory drive when a VMU is inserted into the upper slot of Player 1's controller.
 - A serial device shows up on the PC once attached - open serial terminal (BAUD and other settings don't matter), type `h`, and then press enter to see available instructions.
 

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,19 @@
 #!/bin/sh
 
-BUILD_DIR="build"
+# Provide one of the following as argument to adjust flavor
+# pico (default)
+# pico_w
+# pico2
+# pico2_w
+
+FLAVOR=pico
+
+if [ $# -gt 0 ]; then
+FLAVOR=$1
+shift
+fi
+
+BUILD_DIR="build-${FLAVOR}"
 DIST_DIR="dist"
 GCC="/usr/bin/arm-none-eabi-gcc"
 GPP="/usr/bin/arm-none-eabi-g++"
@@ -12,6 +25,7 @@ rm ${BUILD_DIR}/src/*/*/*.uf2
 
 cmake \
     --no-warn-unused-cli \
+    -DPICO_BOARD=${FLAVOR} \
     -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE \
     -DCMAKE_BUILD_TYPE:STRING=Debug \
     -DCMAKE_C_COMPILER:FILEPATH=${GCC} \
@@ -42,5 +56,9 @@ if [ $STATUS -ne 0 ]; then
 fi
 
 mkdir -p ${DIST_DIR}
-rm -rf ${DIST_DIR}/*
-cp ${BUILD_DIR}/src/*/*/*.uf2 ${DIST_DIR}
+rm -rf "${DIST_DIR}/*-${FLAVOR}.uf2"
+for file in ${BUILD_DIR}/src/*/*/*.uf2
+do
+    filename=$(basename $file)
+    mv -v -- "$file" "${DIST_DIR}/${filename%.uf2}-${FLAVOR}.uf2"
+done

--- a/build.sh
+++ b/build.sh
@@ -1,20 +1,27 @@
 #!/bin/sh
 
-# Provide one of the following as argument to adjust flavor
+# USAGE:
+# build.sh <platform> <dist-suffix>
+
+# Provide one of the following as argument to adjust platform
 # pico (default)
-# pico_w
 # pico2
-# pico2_w
 
 FLAVOR=pico
+DIST_SUFFIX=
 
 if [ $# -gt 0 ]; then
 FLAVOR=$1
 shift
 fi
 
+if [ $# -gt 0 ]; then
+DIST_SUFFIX="-$1"
+shift
+fi
+
 BUILD_DIR="build-${FLAVOR}"
-DIST_DIR="dist"
+DIST_DIR="./dist"
 GCC="/usr/bin/arm-none-eabi-gcc"
 GPP="/usr/bin/arm-none-eabi-g++"
 
@@ -27,7 +34,7 @@ cmake \
     --no-warn-unused-cli \
     -DPICO_BOARD=${FLAVOR} \
     -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE \
-    -DCMAKE_BUILD_TYPE:STRING=Debug \
+    -DCMAKE_BUILD_TYPE:STRING=Release \
     -DCMAKE_C_COMPILER:FILEPATH=${GCC} \
     -DCMAKE_CXX_COMPILER:FILEPATH=${GPP} \
     -DDREAMCAST_CONTROLLER_USB_PICO_TEST:BOOL=FALSE \
@@ -44,7 +51,7 @@ fi
 
 cmake \
     --build ${BUILD_DIR} \
-    --config Debug \
+    --config Release \
     --target all \
     -j 10 \
 
@@ -56,9 +63,8 @@ if [ $STATUS -ne 0 ]; then
 fi
 
 mkdir -p ${DIST_DIR}
-rm -rf "${DIST_DIR}/*-${FLAVOR}.uf2"
 for file in ${BUILD_DIR}/src/*/*/*.uf2
 do
     filename=$(basename $file)
-    mv -v -- "$file" "${DIST_DIR}/${filename%.uf2}-${FLAVOR}.uf2"
+    cp -v -- "$file" "${DIST_DIR}/${filename%.uf2}${DIST_SUFFIX}.uf2"
 done

--- a/src/hal/MapleBus/MapleBus.cpp
+++ b/src/hal/MapleBus/MapleBus.cpp
@@ -24,7 +24,6 @@
 #include "MapleBus.hpp"
 #include "pico/stdlib.h"
 #include "hardware/structs/systick.h"
-#include "hardware/regs/m0plus.h"
 #include "hardware/irq.h"
 #include "configuration.h"
 #include "maple_in.pio.h"

--- a/src/main/Client/client_usb_host.cpp
+++ b/src/main/Client/client_usb_host.cpp
@@ -24,6 +24,7 @@
 #ifndef ENABLE_UNIT_TEST
 
 #include "pico/stdlib.h"
+#include "hardware/clocks.h"
 #include "pico/multicore.h"
 #include "pico/platform.h"
 

--- a/src/main/Host/host.cpp
+++ b/src/main/Host/host.cpp
@@ -24,6 +24,7 @@
 #ifndef ENABLE_UNIT_TEST
 
 #include "pico/stdlib.h"
+#include "hardware/clocks.h"
 #include "pico/multicore.h"
 
 #include "configuration.h"

--- a/very_clean.sh
+++ b/very_clean.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
 rm -rf build
+rm -rf build-pico
+rm -rf build-pico_w
+rm -rf build-pico2
+rm -rf build-pico2_w
 rm -rf build-test
 rm -rf dist
-


### PR DESCRIPTION
NOTE: There is no way to activate the LED on the W variants of the board with this project. In order to do so, the CYW43 chip would need to be activated which uses the PIO for communication. This hardware is already reserved for Maple Bus communication. However, turning on and off GP25 on the W should at least be benign. It activates the CS on the CYW43 which shouldn't do anything because it won't be powered.